### PR TITLE
update stripe balance call

### DIFF
--- a/src/Traits/Payable.php
+++ b/src/Traits/Payable.php
@@ -83,7 +83,7 @@ trait Payable
 
     public function getAccountBalance(): Balance
     {
-        return static::$stripe->balance->retrieve([
+        return static::$stripe->balance->retrieve([], [
             'stripe_account' => $this->getStripeAccountId(),
         ]);
     }


### PR DESCRIPTION
this call was returning errors because the first argument should be the balance $params and stripe_account would be the always the second argument